### PR TITLE
Improving the assertion

### DIFF
--- a/client/test/consumerPact.spec.js
+++ b/client/test/consumerPact.spec.js
@@ -8,8 +8,9 @@ const expect = chai.expect
 const API_PORT = process.env.API_PORT || 9123
 //chai.use(chaiAsPromised)
 
-var PactResponses = require('./PactResponses')
-var FilmsService = require('../FilmsServiceClient');
+const PactResponses = require('./PactResponses')
+const FilmsService = require('../FilmsServiceClient');
+const Film = require('../model/filmClientModel');
 // Configure and import consumer API
 // Note that we update the API endpoint to point at the Mock Service
 const LOG_LEVEL = process.env.LOG_LEVEL || 'WARN'
@@ -63,12 +64,9 @@ describe('Pact for Film Provider', () => {
         it('returns all films', () => {
             return filmService.getAllFilms()
                 .then(response => {
-                    expect(response).to.be.not.null;
-                    expect(response).to.have.length(3);
-                    expect(response[0].Descripcion).to.equal("Space");
-
-                    //Generated value it's used on client tests
-                    expect(response[2].id).to.equal(10);
+                    expect(response).to.deep.members([new Film(1, "Star Wars", "Space", 1980), 
+                                                      new Film(2, "Superman", "Comic", 1986),
+                                                      new Film(10, "Indiana Jones", "Adventures", 1985)]);
                 });
         });
     });
@@ -111,8 +109,7 @@ describe('Pact for Film Provider', () => {
         it('returns one film', () => {
             return filmService.getFilmById(1)
                 .then(response => {
-                    expect(response).to.be.not.null;
-                    expect(response.Year).to.be.eq(1980);
+                    expect(response).to.deep.equal(new Film(1, "Star Wars", "Space", 1980));
                 });
         });
         it('returns not found when film does not exist', () => {


### PR DESCRIPTION
This proposal has two goals:
* Comparing all the properties. I've seen problems because of comparing only 1 or 2 properties. Testing frameworks include specific assertions to facilitate this kind of comparisons: [Chai Assertion Library .deep](https://www.chaijs.com/api/bdd/#deep). As a consequence, less expectations are needed (not null, size, ...).
* Show the decoupling between the result of the client (internal objects) and the service response (JSON) more clearly. I think it will be useful when you explain the need of the 2 parts: interaction definition (pair of expected request and minimal expected response) and the real test of the consumer (how process the response after a request).

I hope this it's useful for you. I loved [your video](https://youtu.be/-0eHk4fvtb0?t=796) and [your diagram about Pact](https://raw.githubusercontent.com/morvader/ContractTesting_Pact/master/Docs/ContractDrivenTesting.png), the best diagram I've seen about it until now! :clap: :clap: :clap: 